### PR TITLE
fix 7&8.lua error

### DIFF
--- a/src/main/7.lua
+++ b/src/main/7.lua
@@ -1151,4 +1151,4 @@ c = {
    
 }
 
-m.executeOrders(b)
+m.executeOrders(a)

--- a/src/main/8.lua
+++ b/src/main/8.lua
@@ -953,4 +953,4 @@ a = {
 -- viridian-2
 }
 
-m.executeOrders(b)
+m.executeOrders(a)


### PR DESCRIPTION
This change fix that I had when running 7.lua. Random movements the same as 8.lua. I think you were executing the wrong list of inputs.